### PR TITLE
provenance-io -> FigureTechnologies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM nginx:1.21.6-alpine
 ENV GAS_PRICE 19050
 ENV GAS_PRICE_DENOM nhash
 
-LABEL org.opencontainers.image.source=https://github.com/provenance-io/gas-price-service
+LABEL org.opencontainers.image.source=https://github.com/FigureTechnologies/gas-price-service
 
 COPY --from=go /go/bin/coin-json-to-proto /usr/bin/coin-json-to-proto
 

--- a/go/convert.go
+++ b/go/convert.go
@@ -4,9 +4,9 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/FigureTechnologies/coin-json-to-proto/coin/github.com/cosmos/cosmos-sdk/types"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
-	"github.com/provenance-io/coin-json-to-proto/coin/github.com/cosmos/cosmos-sdk/types"
 )
 
 func main() {

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/provenance-io/coin-json-to-proto
+module github.com/FigureTechnologies/coin-json-to-proto
 
 go 1.17
 


### PR DESCRIPTION
* No other updates should be necessary since we were just hosting this with GitHub's Container Repository, just publish a new version and then deploy it over at https://github.com/FigureTechnologies/gas-price-service-deployment